### PR TITLE
Fix MouseEventArgs.Position not being view-relative on Mac

### DIFF
--- a/Source/OxyPlot.Xamarin.Mac/ConverterExtensions.cs
+++ b/Source/OxyPlot.Xamarin.Mac/ConverterExtensions.cs
@@ -31,15 +31,10 @@ namespace OxyPlot.Xamarin.Mac
             return new ScreenPoint (p.X, p.Y);
         }
 
-        /// <summary>
-        /// Converts a <see cref="System.Drawing.PointF" /> to a <see cref="ScreenPoint" />.
-        /// </summary>
-        /// <param name="p">The point to convert.</param>
-		/// <param name="bounds">The bounds of the window.</param> 
-        /// <returns>The converted point.</returns>
-        public static ScreenPoint LocationToScreenPoint (this CGPoint p, CGRect bounds)
+        public static ScreenPoint PositionAsScreenPointRelativeToPlotView (this NSEvent p, PlotView plotView)
         {
-            return new ScreenPoint (p.X, bounds.Height - p.Y);
+            var relativePoint = plotView.ConvertPointFromView(p.LocationInWindow, null);
+            return new ScreenPoint (relativePoint.X, relativePoint.Y);
         }
 
         /// <summary>
@@ -157,33 +152,21 @@ namespace OxyPlot.Xamarin.Mac
             return keys;
         }
 
-		/// <summary>
-		/// Converts a <see cref="NSEvent" /> to a <see cref="OxyMouseDownEventArgs" />.
-		/// </summary>
-		/// <param name="theEvent">The event to convert.</param>
-		/// <param name="bounds">The bounds of the window.</param> 
-		/// <returns>The converted event arguments.</returns>
-        public static OxyMouseDownEventArgs ToMouseDownEventArgs (this NSEvent theEvent, CGRect bounds)
+        public static OxyMouseDownEventArgs ToMouseDownEventArgs (this NSEvent theEvent, PlotView view)
         {
             // https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSEvent_Class/Reference/Reference.html
             return new OxyMouseDownEventArgs {
-                Position = theEvent.LocationInWindow.LocationToScreenPoint (bounds),
+                Position = theEvent.PositionAsScreenPointRelativeToPlotView(view),
                 ChangedButton = theEvent.Type.ToButton (),
                 ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
                 ClickCount = (int)theEvent.ClickCount,
             };
         }
 
-		/// <summary>
-		/// Converts a <see cref="NSEvent" /> to a <see cref="OxyMouseEventArgs" />.
-		/// </summary>
-		/// <param name="theEvent">The event to convert.</param>
-		/// <param name="bounds">The bounds of the window.</param> 
-		/// <returns>The converted event arguments.</returns>
-        public static OxyMouseEventArgs ToMouseEventArgs (this NSEvent theEvent, CGRect bounds)
+        public static OxyMouseEventArgs ToMouseEventArgs (this NSEvent theEvent, PlotView view)
         {
             return new OxyMouseEventArgs {
-                Position = theEvent.LocationInWindow.LocationToScreenPoint (bounds),
+                Position = theEvent.PositionAsScreenPointRelativeToPlotView(view),
                 ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
             };
         }
@@ -194,11 +177,11 @@ namespace OxyPlot.Xamarin.Mac
 		/// <param name="theEvent">The event to convert.</param>
 		/// <param name="bounds">The bounds of the window.</param> 
 		/// <returns>The converted event arguments.</returns>
-        public static OxyMouseWheelEventArgs ToMouseWheelEventArgs (this NSEvent theEvent, CGRect bounds)
+        public static OxyMouseWheelEventArgs ToMouseWheelEventArgs (this NSEvent theEvent, PlotView view)
         {
             return new OxyMouseWheelEventArgs {
                 Delta = (int)theEvent.ScrollingDeltaY,
-                Position = theEvent.LocationInWindow.LocationToScreenPoint (bounds),
+                Position = theEvent.PositionAsScreenPointRelativeToPlotView(view),
                 ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
             };
         }

--- a/Source/OxyPlot.Xamarin.Mac/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.Mac/PlotView.cs
@@ -313,7 +313,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseDown (NSEvent theEvent)
         {
             base.MouseDown (theEvent);
-            this.ActualController.HandleMouseDown (this, theEvent.ToMouseDownEventArgs(this.Bounds));
+            this.ActualController.HandleMouseDown (this, theEvent.ToMouseDownEventArgs(this));
         }
 
 		/// <summary>
@@ -323,7 +323,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseDragged (NSEvent theEvent)
         {
             base.MouseDragged (theEvent);
-            this.ActualController.HandleMouseMove (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseMove (this, theEvent.ToMouseEventArgs (this));
         }
 
 		/// <summary>
@@ -333,7 +333,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseMoved (NSEvent theEvent)
         {
             base.MouseMoved (theEvent);
-            this.ActualController.HandleMouseMove (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseMove (this, theEvent.ToMouseEventArgs (this));
         }
 
 		/// <summary>
@@ -343,7 +343,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseUp (NSEvent theEvent)
         {
             base.MouseUp (theEvent);
-            this.ActualController.HandleMouseUp (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseUp (this, theEvent.ToMouseEventArgs (this));
         }
 
 		/// <summary>
@@ -353,7 +353,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseEntered (NSEvent theEvent)
         {
             base.MouseEntered (theEvent);
-            this.ActualController.HandleMouseEnter (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseEnter (this, theEvent.ToMouseEventArgs (this));
         }
 
 		/// <summary>
@@ -363,7 +363,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseExited (NSEvent theEvent)
         {
             base.MouseExited (theEvent);
-            this.ActualController.HandleMouseLeave (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseLeave (this, theEvent.ToMouseEventArgs (this));
         }
 
 		/// <summary>
@@ -374,7 +374,7 @@ namespace OxyPlot.Xamarin.Mac
         {
             // TODO: use scroll events to pan?
             base.ScrollWheel (theEvent);
-            this.ActualController.HandleMouseWheel (this, theEvent.ToMouseWheelEventArgs (this.Bounds));
+            this.ActualController.HandleMouseWheel (this, theEvent.ToMouseWheelEventArgs (this));
         }
 
 		/// <summary>


### PR DESCRIPTION
This bug is being fixed to support tracking mouse hover on Mac.